### PR TITLE
feat: Add script parameters / input variables

### DIFF
--- a/prisma/migrations/20260214180324_add_script_parameters/migration.sql
+++ b/prisma/migrations/20260214180324_add_script_parameters/migration.sql
@@ -1,0 +1,31 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_scripts" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "language" TEXT NOT NULL DEFAULT 'python',
+    "interpreter" TEXT,
+    "webhook_token" TEXT,
+    "schedule_cron" TEXT,
+    "schedule_enabled" BOOLEAN NOT NULL DEFAULT false,
+    "parameters" TEXT NOT NULL DEFAULT '[]',
+    "gist_id" TEXT,
+    "gist_url" TEXT,
+    "sync_to_gist" BOOLEAN NOT NULL DEFAULT false,
+    "gist_filename" TEXT,
+    "collection_id" TEXT,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME NOT NULL,
+    "last_run" DATETIME,
+    CONSTRAINT "scripts_collection_id_fkey" FOREIGN KEY ("collection_id") REFERENCES "collections" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_scripts" ("collection_id", "created_at", "description", "filename", "gist_filename", "gist_id", "gist_url", "id", "interpreter", "language", "last_run", "name", "schedule_cron", "schedule_enabled", "sync_to_gist", "updated_at", "webhook_token") SELECT "collection_id", "created_at", "description", "filename", "gist_filename", "gist_id", "gist_url", "id", "interpreter", "language", "last_run", "name", "schedule_cron", "schedule_enabled", "sync_to_gist", "updated_at", "webhook_token" FROM "scripts";
+DROP TABLE "scripts";
+ALTER TABLE "new_scripts" RENAME TO "scripts";
+CREATE UNIQUE INDEX "scripts_name_key" ON "scripts"("name");
+CREATE UNIQUE INDEX "scripts_webhook_token_key" ON "scripts"("webhook_token");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model Script {
   webhookToken    String?     @unique @map("webhook_token")
   scheduleCron    String?     @map("schedule_cron")
   scheduleEnabled Boolean     @default(false) @map("schedule_enabled")
+  parameters      String      @default("[]")
   gistId          String?     @map("gist_id")
   gistUrl         String?     @map("gist_url")
   syncToGist      Boolean     @default(false) @map("sync_to_gist")

--- a/src/app/api/scripts/[id]/route.ts
+++ b/src/app/api/scripts/[id]/route.ts
@@ -27,6 +27,7 @@ export async function GET(
     content,
     language: script.language,
     interpreter: script.interpreter,
+    parameters: (() => { try { return JSON.parse(script.parameters ?? '[]') } catch { return [] } })(),
     created_at: script.createdAt.toISOString(),
     updated_at: script.updatedAt.toISOString(),
   })

--- a/src/app/api/scripts/[id]/run/route.ts
+++ b/src/app/api/scripts/[id]/run/route.ts
@@ -13,6 +13,17 @@ export async function POST(
     return NextResponse.json({ error: 'Script not found' }, { status: 404 })
   }
 
+  // Parse body for optional paramValues — body may be absent for scripts with no params
+  let paramValues: Record<string, string> | undefined
+  try {
+    const body = await req.json()
+    if (body?.paramValues && typeof body.paramValues === 'object') {
+      paramValues = body.paramValues
+    }
+  } catch {
+    // No body or invalid JSON — run without params
+  }
+
   const build = await prisma.build.create({
     data: {
       scriptId: script.id,
@@ -22,7 +33,7 @@ export async function POST(
   })
 
   // Fire-and-forget - don't await
-  executeScriptAsync(build.id, script).catch(err => {
+  executeScriptAsync(build.id, script, paramValues).catch(err => {
     console.error('[Run] Script execution error:', err)
   })
 

--- a/src/components/ParametersPanel.tsx
+++ b/src/components/ParametersPanel.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { useState } from 'react'
+import { Plus, Trash2, ChevronDown, ChevronUp, SlidersHorizontal } from 'lucide-react'
+import type { ScriptParameter } from '@/lib/types'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
+
+interface Props {
+    parameters: ScriptParameter[]
+    onChange: (params: ScriptParameter[]) => void
+}
+
+export function ParametersPanel({ parameters, onChange }: Props) {
+    const [isExpanded, setIsExpanded] = useState(true)
+
+    const addParam = () => {
+        const newParam: ScriptParameter = {
+            name: '',
+            type: 'string',
+            required: false,
+            defaultValue: '',
+            description: '',
+        }
+        onChange([...parameters, newParam])
+    }
+
+    const removeParam = (index: number) => {
+        onChange(parameters.filter((_, i) => i !== index))
+    }
+
+    const updateParam = (index: number, partial: Partial<ScriptParameter>) => {
+        onChange(parameters.map((p, i) => (i === index ? { ...p, ...partial } : p)))
+    }
+
+    return (
+        <div>
+            <div className="flex items-center justify-between mb-2">
+                <h3 className="text-xs font-semibold text-slate-500 uppercase flex items-center gap-1">
+                    <SlidersHorizontal className="h-3 w-3" /> Parameters
+                </h3>
+                <div className="flex items-center gap-1">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-5 w-5"
+                        onClick={addParam}
+                        title="Add parameter"
+                    >
+                        <Plus className="h-3 w-3 text-slate-400" />
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-5 w-5"
+                        onClick={() => setIsExpanded(!isExpanded)}
+                    >
+                        {isExpanded
+                            ? <ChevronUp className="h-3 w-3 text-slate-400" />
+                            : <ChevronDown className="h-3 w-3 text-slate-400" />
+                        }
+                    </Button>
+                </div>
+            </div>
+
+            {isExpanded && (
+                <div className="space-y-2">
+                    {parameters.length === 0 && (
+                        <p className="text-[10px] text-slate-400 italic">
+                            No parameters. Click <span className="font-semibold">+</span> to add one.
+                        </p>
+                    )}
+
+                    {parameters.map((param, i) => (
+                        <div
+                            key={i}
+                            className="border border-slate-200 rounded p-2 bg-slate-50 space-y-1.5"
+                        >
+                            {/* Name + type + delete row */}
+                            <div className="flex items-center gap-1">
+                                <Input
+                                    className="h-6 text-xs font-mono flex-1"
+                                    placeholder="PARAM_NAME"
+                                    value={param.name}
+                                    onChange={(e) =>
+                                        updateParam(i, {
+                                            name: e.target.value
+                                                .toUpperCase()
+                                                .replace(/\s/g, '_'),
+                                        })
+                                    }
+                                />
+                                <Select
+                                    value={param.type}
+                                    onValueChange={(v) =>
+                                        updateParam(i, { type: v as ScriptParameter['type'] })
+                                    }
+                                >
+                                    <SelectTrigger className="h-6 w-[76px] text-[10px]">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="string">string</SelectItem>
+                                        <SelectItem value="number">number</SelectItem>
+                                        <SelectItem value="boolean">bool</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-5 w-5 shrink-0"
+                                    onClick={() => removeParam(i)}
+                                    title="Remove parameter"
+                                >
+                                    <Trash2 className="h-3 w-3 text-red-400" />
+                                </Button>
+                            </div>
+
+                            {/* Default value */}
+                            <Input
+                                className="h-6 text-[10px]"
+                                placeholder="Default value (optional)"
+                                value={param.defaultValue ?? ''}
+                                onChange={(e) =>
+                                    updateParam(i, { defaultValue: e.target.value })
+                                }
+                            />
+
+                            {/* Description */}
+                            <Input
+                                className="h-6 text-[10px]"
+                                placeholder="Description (optional)"
+                                value={param.description ?? ''}
+                                onChange={(e) =>
+                                    updateParam(i, { description: e.target.value })
+                                }
+                            />
+
+                            {/* Required checkbox */}
+                            <div className="flex items-center gap-2">
+                                <Checkbox
+                                    id={`req-${i}`}
+                                    checked={param.required}
+                                    onCheckedChange={(v) =>
+                                        updateParam(i, { required: !!v })
+                                    }
+                                    className="h-3 w-3"
+                                />
+                                <Label
+                                    htmlFor={`req-${i}`}
+                                    className="text-[10px] text-slate-500 cursor-pointer"
+                                >
+                                    Required
+                                </Label>
+                            </div>
+                        </div>
+                    ))}
+
+                    {parameters.length > 0 && (
+                        <p className="text-[10px] text-slate-400 mt-1">
+                            Injected as env vars by exact name (e.g.{' '}
+                            <code className="bg-slate-100 px-0.5 rounded">API_KEY</code>)
+                        </p>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/components/RunInputsDialog.tsx
+++ b/src/components/RunInputsDialog.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState } from 'react'
+import type { ScriptParameter } from '@/lib/types'
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogFooter,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+
+interface Props {
+    open: boolean
+    parameters: ScriptParameter[]
+    onRun: (values: Record<string, string>) => void
+    onCancel: () => void
+}
+
+export function RunInputsDialog({ open, parameters, onRun, onCancel }: Props) {
+    const [values, setValues] = useState<Record<string, string>>(() => {
+        const init: Record<string, string> = {}
+        for (const p of parameters) {
+            init[p.name] = p.defaultValue ?? (p.type === 'boolean' ? 'false' : '')
+        }
+        return init
+    })
+
+    const [errors, setErrors] = useState<Record<string, string>>({})
+
+    const setValue = (name: string, val: string) => {
+        setValues((prev) => ({ ...prev, [name]: val }))
+        if (errors[name]) {
+            setErrors((prev) => ({ ...prev, [name]: '' }))
+        }
+    }
+
+    const validate = (): boolean => {
+        const newErrors: Record<string, string> = {}
+        for (const p of parameters) {
+            const val = values[p.name] ?? ''
+            if (p.required && val.trim() === '') {
+                newErrors[p.name] = 'Required'
+            } else if (
+                p.type === 'number' &&
+                val.trim() !== '' &&
+                isNaN(Number(val))
+            ) {
+                newErrors[p.name] = 'Must be a number'
+            }
+        }
+        setErrors(newErrors)
+        return Object.keys(newErrors).length === 0
+    }
+
+    const handleRun = () => {
+        if (!validate()) return
+        onRun(values)
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={(o) => { if (!o) onCancel() }}>
+            <DialogContent className="max-w-md">
+                <DialogHeader>
+                    <DialogTitle className="text-sm">Run — Fill Parameters</DialogTitle>
+                </DialogHeader>
+
+                <div className="space-y-4 py-1 max-h-[60vh] overflow-y-auto pr-1">
+                    {parameters.map((p) => (
+                        <div key={p.name} className="space-y-1">
+                            <Label className="text-xs font-mono font-semibold flex items-center gap-1">
+                                {p.name}
+                                {p.required && (
+                                    <span className="text-red-500">*</span>
+                                )}
+                                <span className="ml-1 text-[10px] font-normal text-slate-400 font-sans">
+                                    ({p.type})
+                                </span>
+                            </Label>
+                            {p.description && (
+                                <p className="text-[10px] text-slate-400">{p.description}</p>
+                            )}
+                            {p.type === 'boolean' ? (
+                                <div className="flex items-center gap-2">
+                                    <Switch
+                                        checked={values[p.name] === 'true'}
+                                        onCheckedChange={(v) =>
+                                            setValue(p.name, v ? 'true' : 'false')
+                                        }
+                                    />
+                                    <span className="text-xs text-slate-500 font-mono">
+                                        {values[p.name] === 'true' ? 'true' : 'false'}
+                                    </span>
+                                </div>
+                            ) : (
+                                <Input
+                                    className="h-7 text-xs font-mono"
+                                    type={p.type === 'number' ? 'number' : 'text'}
+                                    value={values[p.name] ?? ''}
+                                    onChange={(e) => setValue(p.name, e.target.value)}
+                                    placeholder={p.defaultValue ?? `Enter ${p.name}`}
+                                />
+                            )}
+                            {errors[p.name] && (
+                                <p className="text-[10px] text-red-500">{errors[p.name]}</p>
+                            )}
+                        </div>
+                    ))}
+                </div>
+
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="text-xs"
+                        onClick={onCancel}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        size="sm"
+                        className="text-xs bg-green-600 hover:bg-green-700 text-white"
+                        onClick={handleRun}
+                    >
+                        Run
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,7 @@
+export interface ScriptParameter {
+  name: string          // e.g. "API_KEY" — injected as env var of same name
+  type: 'string' | 'number' | 'boolean'
+  required: boolean
+  defaultValue?: string
+  description?: string
+}


### PR DESCRIPTION
- Add ScriptParameter type (name, type, required, defaultValue, description)
- Prisma migration: add parameters column (JSON string) to Script model
- scriptRunner: accept paramValues 3rd arg, merge into spawn env
- Run API: parse paramValues from request body, pass to runner
- Webhook API: extract matching param values from webhook payload
- Scheduler: build param defaults dict for scheduled runs
- Scripts API (list + create/update): read/write parameters JSON field
- Redux: add parameters to Script interface; widen runScript + saveScript thunks
- ParametersPanel component: define/edit parameters in the right panel (collapsible)
- RunInputsDialog component: fill parameter values before running (with validation)
- ScriptsManager: wire in both components; show dialog when script has params