### PR TITLE
fix: Electron dev mode — skip server spawn, share DESKTOP_AUTH_SECRET

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,40 +4,35 @@ import path from 'path'
 import http from 'http'
 import crypto from 'crypto'
 
-const PORT = parseInt(process.env.ELECTRON_PORT ?? '3141', 10)
-const DESKTOP_SECRET = crypto.randomBytes(32).toString('hex')
+// In dev mode, `concurrently` already runs the Next.js server on port 3000.
+// In production (packaged), Electron spawns the standalone server itself.
+const IS_DEV = !app.isPackaged
+const DEV_PORT = parseInt(process.env.DEV_PORT ?? '3000', 10)
+const PROD_PORT = parseInt(process.env.ELECTRON_PORT ?? '3141', 10)
+const PORT = IS_DEV ? DEV_PORT : PROD_PORT
+
+// In dev, DESKTOP_AUTH_SECRET is set by the npm script so both processes share it.
+// In production, generate a fresh ephemeral secret per launch.
+const DESKTOP_SECRET = process.env.DESKTOP_AUTH_SECRET ?? crypto.randomBytes(32).toString('hex')
 let serverProcess: ChildProcess | null = null
 let mainWindow: BrowserWindow | null = null
 
 function startServer() {
-  const isDev = !app.isPackaged
-
-  let cmd: string
-  let args: string[]
-
-  if (isDev) {
-    // Dev: run ts-node with the custom server
-    cmd = process.platform === 'win32' ? 'npx.cmd' : 'npx'
-    args = [
-      'ts-node',
-      '-r', 'tsconfig-paths/register',
-      '--project', 'tsconfig.server.json',
-      'server.ts',
-    ]
-  } else {
-    // Prod: run compiled server.js from resources
-    cmd = process.execPath.replace('ScriptManager.exe', '').replace('ScriptManager', '') + 'node'
-    args = [path.join(process.resourcesPath, 'app', 'server.js')]
+  if (IS_DEV) {
+    // Dev: server is already running via `concurrently`, nothing to spawn
+    return
   }
 
-  const cwd = isDev ? path.join(__dirname, '..') : undefined
+  // Production: spawn the compiled standalone server
+  const nodeExe = process.platform === 'win32' ? 'node.exe' : 'node'
+  const nodePath = path.join(path.dirname(process.execPath), nodeExe)
+  const serverScript = path.join(process.resourcesPath, 'app', 'server.js')
 
-  serverProcess = spawn(cmd, args, {
-    cwd,
+  serverProcess = spawn(nodePath, [serverScript], {
     env: {
       ...process.env,
       PORT: String(PORT),
-      NODE_ENV: isDev ? 'development' : 'production',
+      NODE_ENV: 'production',
       DESKTOP_AUTH_SECRET: DESKTOP_SECRET,
       DATABASE_URL: `file:${path.join(app.getPath('userData'), 'scriptmanager.db')}`,
       SCRIPTS_DIR: path.join(app.getPath('userData'), 'user_scripts'),

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "db:studio": "prisma studio",
     "next:dev": "next dev",
     "cli": "node ./cli/sm.mjs",
-    "electron:dev": "concurrently \"npm run dev\" \"wait-on http://localhost:3000 && electron .\"",
+    "electron:dev": "cross-env DESKTOP_AUTH_SECRET=dev-desktop-secret-local concurrently \"npm run dev\" \"wait-on http://localhost:3000 && electron .\"",
     "electron:build": "cross-env ELECTRON_BUILD=1 next build && tsc -p electron/tsconfig.json && electron-builder",
     "electron:pack": "cross-env ELECTRON_BUILD=1 next build && tsc -p electron/tsconfig.json && electron-builder --dir"
   },


### PR DESCRIPTION
In dev mode (npm run electron:dev), the Next.js server is already started by concurrently so electron/main.ts must NOT spawn a second server. The spawn EINVAL on Windows was caused by attempting to run npx.cmd via child_process.spawn without shell:true.

- electron/main.ts: IS_DEV flag skips spawn entirely in dev; in prod uses node binary directly (no shell needed); reads DESKTOP_AUTH_SECRET from env (set by cross-env) rather than generating a random secret, so both the server process and Electron share the same value
- package.json: electron:dev now sets DESKTOP_AUTH_SECRET=dev-desktop- secret-local via cross-env so both processes have a matching value